### PR TITLE
Replace gatttool with native implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const Switchbot = require('switchbot');
+const Switchbot = require('./switchbot');
 
 let Service;
 let Characteristic;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "homebridge": ">= 0.4"
   },
   "dependencies": {
-    "switchbot": ">= 0.0.4"
+    "@abandonware/noble": "^1.9.2-5"
   }
 }

--- a/switchbot.js
+++ b/switchbot.js
@@ -24,6 +24,14 @@ const Switchbot = address => {
     }
   });
 
+  const getState = () => {
+    const advertisement = peripheral.advertisement;
+    const serviceData = advertisement.serviceData;
+    const buf = serviceData[0].data;
+    const byte1 = buf.readUInt8(1);
+    return byte1 & 0b01000000 ? true : false;
+  };
+
   const exec = command => {
     new Promise((resolve, reject) => {
       peripheral.connect(error => {
@@ -43,10 +51,16 @@ const Switchbot = address => {
   };
 
   const turnOn = () => {
+    if (!getState()) {
+      return Promise.resolve();
+    }
     return exec('turnOn');
   };
 
   const turnOff = () => {
+    if (getState()) {
+      return Promise.resolve();
+    }
     return exec('turnOff');
   };
 

--- a/switchbot.js
+++ b/switchbot.js
@@ -1,0 +1,56 @@
+const noble = require('@abandonware/noble');
+
+const uuidPrimary = 'cba20d00224d11e69fb80002a5d5c51b';
+const uuidWrite = 'cba20002224d11e69fb80002a5d5c51b';
+const commands = {
+  turnOn: '570101',
+  turnOff: '570102'
+};
+
+const Switchbot = address => {
+  let peripheral;
+
+  noble.on('stateChange', state => {
+    if (state === 'poweredOn') {
+      noble.startScanning([uuidPrimary], false);
+    } else {
+      noble.stopScanning();
+    }
+  });
+
+  noble.on('discover', discoveredPeripheral => {
+    if (discoveredPeripheral.address === address) {
+      peripheral = discoveredPeripheral;
+    }
+  });
+
+  const exec = command => {
+    new Promise((resolve, reject) => {
+      peripheral.connect(error => {
+        peripheral.discoverAllServicesAndCharacteristics((error, services, chars) => {
+          chars.forEach(char => {
+            if (char.uuid === uuidWrite) {
+              const cmd = new Buffer.from(commands[command], 'hex');
+              char.write(cmd, false, error => {
+                peripheral.disconnect();
+                resolve();
+              });
+            }
+          });
+        });
+      });
+    });
+  };
+
+  const turnOn = () => {
+    return exec('turnOn');
+  };
+
+  const turnOff = () => {
+    return exec('turnOff');
+  };
+
+  return { turnOn, turnOff };
+};
+
+module.exports = Switchbot;

--- a/switchbot.js
+++ b/switchbot.js
@@ -19,7 +19,7 @@ const Switchbot = address => {
   });
 
   noble.on('discover', discoveredPeripheral => {
-    if (discoveredPeripheral.address === address) {
+    if (discoveredPeripheral.address.match(new RegExp(address.replace(/:/g, '.'), 'i'))) {
       peripheral = discoveredPeripheral;
     }
   });


### PR DESCRIPTION
This pull request removes the `switchbot` dependency (which requires `gatttool`) and replaces it with a `noble`-based solution with the equivalent functionality and more.

In addition to being able to use the turn on and off commands, there is state awareness. If a command is issued when the device is already in that state, the promise will be resolved and no action will be taken other than the status changing in the Home app.

The module pattern has been used to encapsulate the peripheral reference, this way the original Homebridge code needs almost no modification.

Also, it appears that npm doesn't properly display the metadata of this repo?
https://www.npmjs.com/package/homebridge-switchbot